### PR TITLE
Testing notes in README; newline before User model injection; require bootstrap_forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ Installing:
 * ```rails generate roles```
 * ```rake db:migrate```
 
+Testing:
+
+* Install a system javascript runtime or uncomment therubyracer in spec/support/Gemfile
+* Run ```rake generate spec``` to generate a test rails app at spec/internal and test it

--- a/lib/generators/roles/roles_generator.rb
+++ b/lib/generators/roles/roles_generator.rb
@@ -38,7 +38,7 @@ This generator makes the following changes to your application:
   def inject_user_roles_behavior
     file_path = "app/models/#{model_name.underscore}.rb"
     if File.exists?(file_path) 
-      code = "# Connects this user object to Role-management behaviors. " +
+      code = "\n # Connects this user object to Role-management behaviors. " +
         "\n include Hydra::RoleManagement::UserRoles\n"        
       inject_into_file file_path, code, { :after => /include Hydra::User/ }
     else

--- a/lib/hydra-role-management.rb
+++ b/lib/hydra-role-management.rb
@@ -1,3 +1,2 @@
-#require "bundler/setup"
 require "hydra/role_management"
-#require "blacklight"
+require 'bootstrap_forms'


### PR DESCRIPTION
I added a few lines about testing to the README.  I also added require bootstrap_forms so you can actually run the internal testing app.  The generator injects a comment and include into the User model, but it didn't have a leading new line so it appended to the previous line in the model.
