### PR TITLE
Allow renaming roles and deleting roles

### DIFF
--- a/app/controllers/concerns/hydra/role_management/roles_behavior.rb
+++ b/app/controllers/concerns/hydra/role_management/roles_behavior.rb
@@ -11,17 +11,38 @@ module Hydra
       end
 
       def show
+        redirect_to role_management.edit_role_path(@role) if can? :edit, Role
       end
 
       def new
       end
 
+      def edit
+      end
+
       def create
         @role.name = params[:role][:name]
         if (@role.save)
-          redirect_to role_management.roles_path, notice: 'Role was successfully created.'
+          redirect_to role_management.edit_role_path(@role), notice: 'Role was successfully created.'
         else
           render action: "new"
+        end
+      end
+
+      def update
+        @role.name = params[:role][:name]
+        if (@role.save)
+          redirect_to role_management.edit_role_path(@role), notice: 'Role was successfully updated.'
+        else
+          render action: "edit"
+        end
+      end
+
+      def destroy
+        if (@role.destroy)
+          redirect_to role_management.roles_path, notice: 'Role was successfully deleted.'
+        else
+          redirect_to role_management.roles_path
         end
       end
 

--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -1,0 +1,28 @@
+<h2>Role:</h2>
+<%= bootstrap_form_for @role, :url=>role_management.role_path(@role) do |f| %>
+  <%= f.text_field :name, :label=> 'Role name' %>
+  <%= f.actions do %>
+    <%= f.submit "Update" %>
+  <% end %>
+<% end %>
+<% if can? :destroy, Role %>
+  <%= button_to "Delete", role_management.role_path(@role), :method=>:delete, :class=>'btn btn-danger' %>
+<% end %>
+<h3>Accounts:</h3>
+<ul>
+  <% @role.users.each do |user| %>
+    <li><%= user.user_key %>
+      <% if can? :remove_user, Role %>
+        <%= button_to "Remove User", role_management.role_user_path(@role, user), :method=>:delete, :class=>'btn btn-danger' %>
+      <% end %>
+    </li>
+  <% end %>
+</ul>
+<h3>Add a new account:</h3>
+<%= bootstrap_form_tag role_management.role_users_path(@role) do %>
+  <%= bootstrap_text_field_tag 'user_key', '', :label=>'User' %>
+  <%= bootstrap_actions do %>
+    <%= bootstrap_submit_tag "Add" %>
+    <%= bootstrap_cancel_tag %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Hydra::RoleManagement::Engine.routes.draw do
   # Generic file routes
-  resources :roles, :only => [:index, :show, :new, :create] do
+  resources :roles do
     resources :users, :only=>[:create, :destroy], :controller => "user_roles"
   end
 end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -14,11 +14,23 @@ describe RolesController do
 
 
   describe "with a user who cannot edit users" do
-    it "should redirect to the homepage" do
+    it "should not be able to view role index" do
       lambda { get :index }.should raise_error CanCan::AccessDenied
     end
-    it "should redirect to the homepage" do
+    it "should not be able to view role" do
       lambda { get :show, id: role }.should raise_error CanCan::AccessDenied
+    end
+    it "should not be able to view new role form" do
+      lambda { get :new }.should raise_error CanCan::AccessDenied
+    end
+    it "should not be able to create a role" do
+      lambda { post :create, :role=>{name: 'my_role'}}.should raise_error CanCan::AccessDenied
+    end
+    it "should not be able to update a role" do
+      lambda { put :update, id: role}.should raise_error CanCan::AccessDenied
+    end
+    it "should not be able to remove a role" do
+      lambda { delete :destroy, id: role}.should raise_error CanCan::AccessDenied
     end
   end
 
@@ -51,7 +63,7 @@ describe RolesController do
 
     it "should be able to create a new role" do
       post :create, :role=>{name: 'my_role'} 
-      response.should redirect_to @routes.url_helpers.roles_path
+      response.should redirect_to @routes.url_helpers.edit_role_path(assigns[:role])
       assigns[:role].should_not be_new_record
       assigns[:role].name.should == 'my_role'
     end
@@ -60,6 +72,36 @@ describe RolesController do
       assigns[:role].name.should == 'my role'
       assigns[:role].errors[:name].should == ['Only letters, numbers, hyphens, underscores and periods are allowed']
       response.should be_successful
+    end
+  end
+
+  describe "with a user who can update roles" do
+    before do
+      ability.can :update, Role
+    end
+
+    it "should be able to update a role" do
+      put :update, id: role, :role=>{name: 'my_role'} 
+      response.should redirect_to @routes.url_helpers.edit_role_path(assigns[:role])
+      assigns[:role].should_not be_new_record
+      assigns[:role].name.should == 'my_role'
+    end
+    it "should not update role with an error" do
+      put :update,  id: role, :role=>{name: 'my role'} 
+      assigns[:role].name.should == 'my role'
+      assigns[:role].errors[:name].should == ['Only letters, numbers, hyphens, underscores and periods are allowed']
+      response.should be_successful
+    end
+  end
+
+  describe "with a user who can remove roles" do
+    before do
+      ability.can :destroy, Role
+    end
+
+    it "should be able to destroy a role" do
+      delete :destroy, id: role 
+      response.should redirect_to @routes.url_helpers.roles_path
     end
   end
 


### PR DESCRIPTION
Added edit, update, and destroy methods on roles concern.  Changed show and create to redirect to edit if the user has privileges.  Added basic edit view that includes renaming the role and deleting the role.
