### PR TITLE
Update build matrix and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ pkg/
 .ruby-gemset
 
 .internal_test_app
+coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 cache:
   bundler: true
 rvm:
-  - 2.4.1
+  - 2.4.2
 env:
   global:
     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
   matrix:
-    - RAILS_VERSION=5.0.2
+    - RAILS_VERSION=5.1.4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 An engine gem to provide a RDBMS backed list of roles and their associated user.  This replaces the hydra default role mapper.
 
-This gem supports Rails 3, 4, and 5.
+As of version 1.0, this gem only supports Rails 5.
 
 ## Installing:
 
@@ -22,12 +22,11 @@ This gem supports Rails 3, 4, and 5.
 ```
 
 ## Testing:
-Given the need to support Rails 3, 4 and 5, the test suite has been parameterized to test against any version of Rails.
 
 * Install a system javascript runtime or uncomment therubyracer in spec/support/Gemfile
 * Ensure that the testing app does not exist: ```bundle exec rake clean```
 * Set Rails version you want to test against.  For example:
-	* ```RAILS_VERSION=3.2.13``` or ```RAILS_VERSION=4.0.0``` or ```RAILS_VERSION=5.0.2```
+	* ```export RAILS_VERSION=5.1.4```
 * Ensure that the correct version of Rails is installed:  ```bundle update```
-* Build test app: ```bundle exec engine_cart:generate```
+* Build test app: ```bundle exec rake engine_cart:generate```
 * And run tests: ```bundle exec rake spec```

--- a/hydra-role-management.gemspec
+++ b/hydra-role-management.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["justin@curationexperts.com"]
   gem.description   = %q{Rails engine to do user roles in an RDBMS for hydra-head}
   gem.summary       = %q{Rails engine to do user roles in an RDBMS for hydra-head}
-  gem.homepage      = "https://github.com/projecthydra/hydra-role-management"
+  gem.homepage      = "https://github.com/samvera/hydra-role-management"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
The README claimed that this gem works against Rails 3, 4, and 5. I tested it against Rails 3 and 4 to see if that's still true and AFAICT it is not. I don't have time to look into what it would take to get more backward compatibility, and I'm not even sure that's important, but at least we can update the README to be more accurate. Also, let's test agains the latest Rails release (5.1.4).