### PR TITLE
Use user.id instead of user in the path for the "Remove User" delete …

### DIFF
--- a/app/views/roles/edit.html.erb
+++ b/app/views/roles/edit.html.erb
@@ -13,7 +13,7 @@
   <% @role.users.each do |user| %>
     <li><%= user.user_key %>
       <% if can? :remove_user, Role %>
-        <%= button_to t('role-management.edit.remove'), role_management.role_user_path(@role, user), :method=>:delete, :class=>'btn btn-danger' %>
+        <%= button_to t('role-management.edit.remove'), role_management.role_user_path(@role, user.id), :method=>:delete, :class=>'btn btn-danger' %>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
…action; addresses #21.

As currently coded, the path for the "Remove User" `delete` method does not use the ID of the user who is to removed from the role but rather what I presume is the user's `user_key`, which, if it has the form of an email address, is converted to something of an "escaped" version ... e.g., "user_a@institution-dot-edu".  When the code tries to find the user (cf. https://github.com/samvera/hydra-role-management/blob/master/app/controllers/concerns/hydra/role_management/user_roles_behavior.rb#L24 ) in performing the deletion, it is unable to and an `ActiveRecord::RecordNotFound` error is thrown: 
```
ActiveRecord::RecordNotFound (Couldn't find User with 'id'=user_@institution-dot-edu)
```

This PR fixes this problem by utilizing the work-around noted by @awead in https://github.com/samvera/hydra-role-management/issues/21#issuecomment-146911788 by which the path for the `delete` method is formulated using the `id` of the user; e.g., `http://localhost:3000/roles/3/users/1`.