### PR TITLE
Updating the dependencies to support bundler 2.0.x releases and to require engine_cart 2.1.x releases

### DIFF
--- a/hydra-role-management.gemspec
+++ b/hydra-role-management.gemspec
@@ -18,10 +18,11 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'blacklight'
   gem.add_dependency 'bootstrap_form'
+  gem.add_dependency 'bundler', '>= 1.5'
   gem.add_dependency 'cancancan'
   gem.add_dependency 'json', '~> 1.8'
   gem.add_development_dependency 'bixby', '~> 1.0.0'
-  gem.add_development_dependency 'engine_cart', '~> 2.0.1'
+  gem.add_development_dependency 'engine_cart', '~> 2.1'
   gem.add_development_dependency 'pry-byebug'
   gem.add_development_dependency 'rails-controller-testing', '~> 0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
This should fix the currently broken build for Travis CI (please compare https://travis-ci.org/samvera/hydra-role-management/builds/460457240 and https://travis-ci.org/jrgriffiniii/hydra-role-management/builds/506944213)