### PR TITLE
Allow for later json versions

### DIFF
--- a/hydra-role-management.gemspec
+++ b/hydra-role-management.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bootstrap_form'
   gem.add_dependency 'bundler', '>= 1.5'
   gem.add_dependency 'cancancan'
-  gem.add_dependency 'json', '~> 1.8'
+  gem.add_dependency 'json', '>= 1.8'
   gem.add_development_dependency 'bixby', '~> 1.0.0'
   gem.add_development_dependency 'engine_cart', '~> 2.1'
   gem.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
Do we need to pin the json gem to version 1.8? The test suite seems to
run fine with 2.x versions of json, and having it pinned at 1.8 is
preventing applications that use hydra-role-management from running on
recent systems that come with json 2.x installed by default.

This PR indicates the need for json greater than or equal to 1.8.

Connected to https://github.com/samvera/hydra-role-management/issues/53