### PR TITLE
Release 1.1.0

### DIFF
--- a/hydra-role-management.gemspec
+++ b/hydra-role-management.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Hydra::RoleManagement::VERSION
   gem.license       = 'Apache 2.0'
+  gem.metadata      = { "rubygems_mfa_required" => "true" }
 
   gem.add_dependency 'blacklight'
   gem.add_dependency 'bootstrap_form'

--- a/lib/hydra/role_management/version.rb
+++ b/lib/hydra/role_management/version.rb
@@ -2,6 +2,6 @@
 
 module Hydra
   module RoleManagement
-    VERSION = '1.0.3'
+    VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
Includes:

- #74 

Making this a minor release (1.1.0) because no Ruby versions were dropped.